### PR TITLE
Add a translation for KO.

### DIFF
--- a/content/latest/blog/new-in-amp-stories-monetization-revamped-bookends-and-metadata@ko.md
+++ b/content/latest/blog/new-in-amp-stories-monetization-revamped-bookends-and-metadata@ko.md
@@ -1,0 +1,36 @@
+---
+class: post-blog post-detail
+type: Blog
+$title: "New in AMP stories: Monetization, Revamped bookends and Metadata"
+id: new-in-amp-stories-monetization-revamped-bookends-and-metadata
+author: Jon Newmuis
+role:  AMP Stories Lead Engineer, Google
+origin: "https://amphtml.wordpress.com/2018/07/16/new-in-amp-stories-monetization-revamped-bookends-and-metadata/amp/"
+excerpt: "We announced the developer preview of AMP stories in February at AMP Conf. Since then, publishers have authored thousands of stories, experimenting with the format and providing valuable feedback to the AMP team. Based on this input, we recently released new capabilities in AMP stories v1.0, open to all developers without origin trials or a [&#8230;]"
+avatar: https://videos.files.wordpress.com/pqK8yXrk/amp_blog_story_ad_hd.mp4
+date_data: 2018-07-16T18:03:22-04:00
+$date: July 16, 2018
+$parent: /content/latest/list-blog.html
+$path: /latest/blog/{base}/
+$localization:
+  path: /{locale}/latest/blog/{base}/
+components:
+  - social-share
+  - iframe
+inlineCSS: .amp-wp-inline-329fdb7771c10d07df9eb73273c95a60{font-weight:400;}
+---
+
+<div class="amp-wp-article-content">
+
+		<p><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">We announced the </span><a href="https://www.ampproject.org/stories/"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">developer preview of AMP stories</span></a><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"> in February at AMP Conf. Since then, publishers have authored thousands of stories, experimenting with the format and providing valuable feedback to the AMP team. Based on this input, </span><b>we recently released </b><a href="https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0"><b>new capabilities in AMP stories v1.0</b></a><b>, open to all developers without origin trials or a whitelist.</b><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"> New features include:</span><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"><br/></span></p><ul><li class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-story/amp-story-ads.md#ad-server-support-for-amp-story-ads"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">New monetization capabilities</span></a><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">, including </span><a href="https://ampbyexample.com/stories/monetization/doubleclick/">ads served from DFP</a><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"> as shown below. (Note: DFP support is in BETA, please </span><a href="https://github.com/ampproject/amphtml/issues/new"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">reach out to us</span></a><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"> if you are interested in testing).</span></li>
+</ul><amp-iframe width="300" height="540" src="https://videopress.com/embed/pqK8yXrk?hd=0&amp;autoPlay=0&amp;permalink=0" frameborder="0" allowfullscreen="" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"><div placeholder="" class="amp-wp-iframe-placeholder"></div></amp-iframe><ul><li class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"><a href="https://www.ampproject.org/docs/reference/components/amp-story#new-metadata-requirements"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">New metadata attributes</span></a><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"> for surfacing stories in platforms and displaying a preview of the story across the AMP stories ecosystem.</span></li>
+<li class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"><a href="https://www.ampproject.org/docs/reference/components/amp-story#new-bookend-capabilities"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">Revamped bookend capabilities</span></a><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"> with richer options including call to action links, text boxes, and portrait and landscape cards</span></li>
+</ul><p><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">Version 1.0 of AMP stories includes these updates and is available today. Upgrade your existing stories to v1.0 using our </span><a href="https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">migration guide</span></a> <span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">to take advantage of the new features.</span></p><p><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">Stay tuned for more developments in the coming months; you can see the </span><a href="https://github.com/ampproject/amphtml/projects/50"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">full roadmap here</span></a><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">. The team is actively working on additional features including:</span></p><ul><li class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"><a href="https://github.com/ampproject/amphtml/issues/12180"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">Paywalls</span></a></li>
+<li class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"><a href="https://github.com/ampproject/amphtml/issues/15955"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">Responsive scaling</span></a></li>
+<li class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60"><a href="https://github.com/ampproject/amphtml/issues/16521"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">Additional clickable elements</span></a></li>
+</ul><p><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">As always, if you have feedback, please </span><a href="https://github.com/ampproject/amphtml/issues/new"><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">let us know on Github</span></a><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">. We look forward to seeing more publishers try AMP stories!</span></p><p><i><span class="amp-wp-inline-329fdb7771c10d07df9eb73273c95a60">Posted by Jon Newmuis, AMP Stories Lead Engineer, Google</span></i></p>	</div>
+
+	
+
+</div>
+


### PR DESCRIPTION
English title for the original blog post: "New in AMP stories: Monetization, Revamped bookends and Metadata"
Korean title: "AMP 스토리 새소식: 광고와 새로워진 북엔드 그리고 메타데이터"