### PR TITLE
Remove a message about "experimental" in a tutorial for amp-story.

### DIFF
--- a/content/docs/design/visual_story.md
+++ b/content/docs/design/visual_story.md
@@ -19,7 +19,7 @@ In this tutorial, we'll introduce you to the [amp-story](/docs/reference/compone
 - Animate elements on a page
 - Keep readers engaged with your content by adding related links to the end of the story
 
-{% call callout('Note', type='note') %} The [amp-story](/docs/reference/components/amp-story.html) component is **experimental**. To sign up for the origin trial to publish pages with this component, please visit <a href="http://bit.ly/amp-story-signup">bit.ly/amp-story-signup</a>. {% endcall %}
+{% call callout('Note', type='note') %} The [amp-story](/docs/reference/components/amp-story.html) component has been [launched](https://www.ampproject.org/latest/blog/new-in-amp-stories-monetization-revamped-bookends-and-metadata/). It's now open to all developers without origin trials or a whitelist. {% endcall %}
 
 
 <div class="start-button">


### PR DESCRIPTION
amp-story has been launched (v1.0): https://www.ampproject.org/latest/blog/new-in-amp-stories-monetization-revamped-bookends-and-metadata/